### PR TITLE
Fix API response types

### DIFF
--- a/src/app/api/sources/[sourceId]/html/route.ts
+++ b/src/app/api/sources/[sourceId]/html/route.ts
@@ -1,6 +1,6 @@
 import { auth } from "@/lib/auth";
 import { findSource } from "@/lib/db/sources";
-import { ApiErrorCode, ApiResponse } from "@/types";
+import { ApiErrorCode, ApiError } from "@/types";
 import { NextAuthRequest } from "next-auth";
 import { NextResponse } from "next/server";
 import { z } from "zod";
@@ -9,6 +9,8 @@ export const GetParamsSchema = z.object({
   sourceId: z.string().nonempty(),
 });
 
+export type GetParamsType = z.infer<typeof GetParamsSchema>;
+
 export interface GetResponseData {
   html: string;
 }
@@ -16,7 +18,7 @@ export interface GetResponseData {
 export const GET = auth(async function GET(
   request: NextAuthRequest,
   { params }: { params: Promise<{ sourceId: string }> },
-): Promise<NextResponse<ApiResponse<GetResponseData>>> {
+): Promise<NextResponse<GetResponseData | ApiError<GetParamsType>>> {
   if (!request.auth) {
     return NextResponse.json(
       { message: "Unauthorized", code: ApiErrorCode.UNAUTHORIZED },
@@ -31,7 +33,7 @@ export const GET = auth(async function GET(
       {
         message: "Validation Error",
         code: ApiErrorCode.VALIDATION_ERROR,
-        validation: z.flattenError(parsedParams.error).fieldErrors,
+        validation: z.flattenError(parsedParams.error),
       },
       {
         status: 400,

--- a/src/app/sources/[sourceId]/UpdateSourceExtractedRecipeForm.tsx
+++ b/src/app/sources/[sourceId]/UpdateSourceExtractedRecipeForm.tsx
@@ -7,8 +7,11 @@ import Textarea from "@/components/elements/Textarea";
 import useSWRImmutable from "swr/immutable";
 import { useActionState } from "react";
 import { updateSourceExtractedRecipeAction } from "@/lib/actions/sources";
-import { GetResponseData } from "@/app/api/sources/[sourceId]/html/extract-recipe/route";
-import { ApiErrorResponse } from "@/types";
+import {
+  GetParamsType,
+  GetResponseData,
+} from "@/app/api/sources/[sourceId]/html/extract-recipe/route";
+import { ApiError } from "@/types";
 
 export default function UpdateSourceExtractedRecipeForm({
   sourceId,
@@ -22,7 +25,7 @@ export default function UpdateSourceExtractedRecipeForm({
 
   const { data, error, isLoading, mutate } = useSWRImmutable<
     GetResponseData,
-    ApiErrorResponse
+    ApiError<GetParamsType>
   >(`/api/sources/${sourceId}/html/extract-recipe`, fetcher);
 
   if (isLoading) {
@@ -36,11 +39,13 @@ export default function UpdateSourceExtractedRecipeForm({
 
         {error.validation && (
           <ul className="text-red-500">
-            {Object.entries(error.validation).map(([key, value]) => (
-              <li key={key}>
-                {key}: {value.join(", ")}
-              </li>
-            ))}
+            {Object.entries(error.validation.fieldErrors).map(
+              ([key, value]) => (
+                <li key={key}>
+                  {key}: {value.join(", ")}
+                </li>
+              ),
+            )}
           </ul>
         )}
 

--- a/src/app/sources/[sourceId]/UpdateSourceFullHtmlForm.tsx
+++ b/src/app/sources/[sourceId]/UpdateSourceFullHtmlForm.tsx
@@ -2,13 +2,15 @@
 
 import Button from "@/components/elements/Button";
 import fetcher from "@/lib/fetcher";
-
 import Textarea from "@/components/elements/Textarea";
 import useSWRImmutable from "swr/immutable";
 import { useActionState } from "react";
 import { updateSourceFullHtmlAction } from "@/lib/actions/sources";
-import { ApiErrorResponse } from "@/types";
-import { GetResponseData } from "@/app/api/sources/[sourceId]/html/route";
+import { ApiError } from "@/types";
+import {
+  GetParamsType,
+  GetResponseData,
+} from "@/app/api/sources/[sourceId]/html/route";
 
 export default function UpdateSourceFullHtmlForm({
   sourceId,
@@ -22,7 +24,7 @@ export default function UpdateSourceFullHtmlForm({
 
   const { data, error, isLoading, mutate } = useSWRImmutable<
     GetResponseData,
-    ApiErrorResponse
+    ApiError<GetParamsType>
   >(`/api/sources/${sourceId}/html`, fetcher);
 
   if (isLoading) {
@@ -36,11 +38,13 @@ export default function UpdateSourceFullHtmlForm({
 
         {error.validation && (
           <ul className="text-red-500">
-            {Object.entries(error.validation).map(([key, value]) => (
-              <li key={key}>
-                {key}: {value.join(", ")}
-              </li>
-            ))}
+            {Object.entries(error.validation.fieldErrors).map(
+              ([key, value]) => (
+                <li key={key}>
+                  {key}: {value.join(", ")}
+                </li>
+              ),
+            )}
           </ul>
         )}
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,15 +1,13 @@
+import { z } from "zod";
+
 export enum ApiErrorCode {
   VALIDATION_ERROR,
   NOT_FOUND,
   UNAUTHORIZED,
 }
 
-export interface ApiErrors {
+export interface ApiError<T> {
   message: string;
   code: ApiErrorCode;
-  validation?: Record<string, string[]>;
+  validation?: z.ZodFlattenedError<T>;
 }
-
-export type ApiSuccessResponse<T> = T;
-export type ApiErrorResponse = ApiErrors;
-export type ApiResponse<T> = ApiSuccessResponse<T> | ApiErrorResponse;


### PR DESCRIPTION
These were just weird. I'm gearing up for some consistency in the way we respond from server actions and was playing around with how to type `z.flattenError` correctly.
